### PR TITLE
fix problem during volumes copy

### DIFF
--- a/docker_clone_volume.sh
+++ b/docker_clone_volume.sh
@@ -47,4 +47,4 @@ docker run --rm \
            -t \
            -v $1:/from \
            -v $2:/to \
-           alpine ash -c "cd /to ; cp -a /from/* /from/.* ."
+           alpine ash -c "cd /to ; cp -a /from/* ."


### PR DESCRIPTION
The copied volume (destination) was created but was empty at the end of the process.
In order to fix it, I had to remove the second argument of the cp command.