### PR TITLE
Fix docker_clone_volume.sh to preserve hard-links

### DIFF
--- a/docker_clone_volume.sh
+++ b/docker_clone_volume.sh
@@ -47,4 +47,4 @@ docker run --rm \
            -t \
            -v $1:/from \
            -v $2:/to \
-           alpine ash -c "cd /from ; cp -av . /to"
+           ubuntu bash -c "cd /from ; cp -av . /to"


### PR DESCRIPTION
When using docker_clone_volume.sh,  I found that when copying a volume with influxdb data, the clones image was bigger than the original.

cause: alpine base image contains a cp version (busybox) which  does _not_ preserve hardlinks, even with the -a option.

This is fixed by using an ubuntu base image instead of alpine.

downside: ubuntu image is larger to download than alpine. (~ 80MB vs 7 MB)

Source volume:

` influxdb_data               380.2 MB`

Before (busybox cp):

` influxdb_data.bak           443.5 MB`

After (ubuntu cp):

` influxdb_data.ubuntu.bak    380.2 MB`

NB: this pull request is not about size, but rather about correctness. A clone should be identical. Not preserving hard links, might actually break apps that depend on it. (like the influxdb database mentioned above)